### PR TITLE
Add functionalities

### DIFF
--- a/src/AbstractNeuralNetworks.jl
+++ b/src/AbstractNeuralNetworks.jl
@@ -37,7 +37,7 @@ module AbstractNeuralNetworks
 
     include("chain.jl")
 
-
+    export AbstractNeuralNetwork
     export NeuralNetwork
 
     include("neural_network.jl")

--- a/src/neural_network.jl
+++ b/src/neural_network.jl
@@ -1,7 +1,7 @@
-abstract type AbstractNeuralNetwork end
+abstract type AbstractNeuralNetwork{AT} end
 
 
-struct NeuralNetwork{AT,MT,PT}
+struct NeuralNetwork{AT,MT,PT} <: AbstractNeuralNetwork{AT}
     architecture::AT
     model::MT
     params::PT

--- a/src/neural_network.jl
+++ b/src/neural_network.jl
@@ -1,9 +1,15 @@
+abstract type AbstractNeuralNetwork end
+
 
 struct NeuralNetwork{AT,MT,PT}
     architecture::AT
     model::MT
     params::PT
 end
+
+architecture(nn::NeuralNetwork) = nn.architecture
+model(nn::NeuralNetwork) = nn.model
+params(nn::NeuralNetwork) = nn.params
 
 function NeuralNetwork(arch::Architecture, model::Chain, backend::Backend, ::Type{T}; kwargs...) where {T}
     # initialize params


### PR DESCRIPTION
I just add the abstract type AbstractNeuralNetwork{AT} with AT for an architecture because it is convenient if we want to add more general neural networks, and three functions to access the parameters, architecture and model of a neural network.