### PR TITLE
Move HDF5 support to a package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ KernelAbstractions = "0.9"
 StaticArrays = "1.9.8"
 Zygote = "0.6, 0.7"
 ZygoteRules = "0.2.7"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,14 @@ authors = ["Michael Kraus"]
 version = "0.6.1"
 
 [weakdeps]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[extensions]
+HDF5Ext = "HDF5"
 
 [deps]
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
-HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -25,10 +28,11 @@ ZygoteRules = "0.2.7"
 julia = "1.6"
 
 [extras]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "LinearAlgebra", "SafeTestsets", "Test", "Zygote"]
+test = ["HDF5", "Random", "LinearAlgebra", "SafeTestsets", "Test", "Zygote"]

--- a/ext/HDF5Ext.jl
+++ b/ext/HDF5Ext.jl
@@ -1,0 +1,43 @@
+module HDF5Ext
+
+using HDF5
+using AbstractNeuralNetworks
+import AbstractNeuralNetworks: h5save, h5load, save, load, NeuralNetworkParameters, params
+
+function _create_group(h5::HDF5.H5DataStore, name)
+    if haskey(h5, name)
+        g = h5[name]
+    else
+        g = HDF5.create_group(h5, name)
+    end
+    return g
+end
+
+function h5save(h5::HDF5.H5DataStore, x::AbstractArray, path::AbstractString)
+    h5[path] = x
+end
+
+function h5save(h5::HDF5.H5DataStore, nt::NamedTuple, path::AbstractString)
+    h5group = _create_group(h5, path)
+    for (k, v) in pairs(nt)
+        h5save(h5group, v, string(k))
+    end
+end
+
+function save(h5::HDF5.H5DataStore, p::NeuralNetworkParameters)
+    h5save(h5, params(p), "/")
+end
+
+h5load(h5::HDF5.Dataset) = read(h5)
+
+function h5load(h5group::HDF5.Group)
+    paramkeys = Tuple(Symbol.(keys(h5group)))
+    paramvals = Tuple(h5load(h5group[k]) for k in keys(h5group))
+    NamedTuple{paramkeys}(paramvals)
+end
+
+function load(::Type{NeuralNetworkParameters}, h5::HDF5.H5DataStore)
+    NeuralNetworkParameters(h5load(h5["/"]))
+end
+
+end

--- a/src/AbstractNeuralNetworks.jl
+++ b/src/AbstractNeuralNetworks.jl
@@ -1,7 +1,5 @@
 module AbstractNeuralNetworks
 
-    using HDF5
-    using HDF5: H5DataStore
     using KernelAbstractions
     using GPUArraysCore: AbstractGPUArray
     using LinearAlgebra

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -22,40 +22,7 @@ Base.values(p::NeuralNetworkParameters) = values(params(p))
 Base.isequal(p1::NeuralNetworkParameters, p2::NeuralNetworkParameters) = isequal(params(p1), params(p2))
 Base.:(==)(p1::NeuralNetworkParameters, p2::NeuralNetworkParameters) = (params(p1) == params(p2))
 
-function _create_group(h5::H5DataStore, name)
-    if haskey(h5, name)
-        g = h5[name]
-    else
-        g = create_group(h5, name)
-    end
-    return g
-end
-
-function h5save(h5::H5DataStore, x::AbstractArray, path::AbstractString)
-    h5[path] = x
-end
-
-function h5save(h5::H5DataStore, nt::NamedTuple, path::AbstractString)
-    h5group = _create_group(h5, path)
-    for (k,v) in pairs(nt)
-        h5save(h5group, v, string(k))
-    end
-end
-
-function save(h5::H5DataStore, p::NeuralNetworkParameters)
-    h5save(h5, params(p), "/")
-end
-
-
-h5load(h5::HDF5.Dataset) = read(h5)
-
-function h5load(h5group::HDF5.Group)
-    paramkeys = Tuple(Symbol.(keys(h5group)))
-    paramvals = Tuple(h5load(h5group[k]) for k in keys(h5group))
-
-    NamedTuple{paramkeys}(paramvals)
-end
-
-function load(::Type{NeuralNetworkParameters}, h5::H5DataStore)
-    NeuralNetworkParameters(h5load(h5["/"]))
-end
+function h5save end
+function h5load end
+function save end
+function load end


### PR DESCRIPTION
## Summary

- HDF5 is moved from `[deps]` to `[weakdeps]`; a corresponding `ext/HDF5Ext.jl` is added
- All `h5save`, `h5load`, `save`, and `load` methods that dispatch on HDF5 types are moved out of `src/parameters.jl` and into the extension
- Zero-method stubs (`function h5save end` etc.) remain in `parameters.jl` so downstream packages (e.g. `GeometricMachineLearning`) can extend the same function objects
- HDF5 is retained in `[extras]`/`[targets]` so the existing HDF5 test file continues to work — `using HDF5` in a test automatically triggers the extension
- Minimum Julia compat bumped from `1.6` → `1.9` (package extensions require Julia 1.9)

## Motivation

Users who do not need to save/load networks are no longer forced to install and precompile HDF5 as part of the `AbstractNeuralNetworks` dependency. This mirrors a corresponding change in `GeometricMachineLearning` (JuliaGNI/GeometricMachineLearning.jl#232).

## Test plan

- [x] Existing `parameters_hdf5_tests.jl` passes (the test already calls `using HDF5` which triggers the extension)
- [x] Loading `AbstractNeuralNetworks` without `HDF5` available does not error
- [x] Calling `save` / `load` without first loading HDF5 gives a `MethodError` (expected — no methods on the stubs)

🤖 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>